### PR TITLE
fix: change http mode to be stateless

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,4 +25,4 @@ repository:
   # description: ""
 
   # Use a comma-separated list of topics to set on the repo (ensure not to use any caps in the topic string).
-  topics: terraform, ibm-cloud, terraform-module
+  topics: terraform, ibm-cloud, terraform-module, mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call-terraform-ci-pipeline:
-    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-python-ci.yml@v1.23.1
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-python-ci.yml@v1.23.2
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ tim-mcp --log-level DEBUG
 
 ### HTTP Mode
 
-HTTP mode runs the server as a web service, ideal for network deployments and multiple concurrent clients.
+HTTP mode runs the server as a stateless web service, ideal for network deployments and multiple concurrent clients. The server runs in stateless mode, which means no session IDs are required and each request is handled independently.
 
 ```bash
 # HTTP mode with defaults (127.0.0.1:8000)
@@ -126,6 +126,12 @@ tim-mcp --http --log-level DEBUG
 **HTTP Server URLs:**
 - Server runs at: `http://host:port/`
 - MCP endpoint: `http://host:port/mcp`
+
+**Stateless Operation:**
+- No session IDs required for HTTP requests
+- Each request is processed independently
+- Ideal for load balancing and horizontal scaling
+- Simplified client implementation
 
 **Production HTTPS:**
 For production deployments requiring HTTPS, use nginx as a reverse proxy:

--- a/examples/http_deployment.md
+++ b/examples/http_deployment.md
@@ -4,11 +4,13 @@ This guide covers deploying TIM-MCP server using HTTP transport for network acce
 
 ## Overview
 
-HTTP transport mode enables TIM-MCP to run as a web service, allowing:
+HTTP transport mode enables TIM-MCP to run as a stateless web service, allowing:
 - Network access from remote clients
 - Multiple concurrent client connections
 - Integration with existing web infrastructure
 - Load balancing and reverse proxy configurations
+- No session ID requirements (stateless operation)
+- Horizontal scaling without session affinity
 
 ## Basic HTTP Deployment
 
@@ -33,6 +35,8 @@ tim-mcp --http --log-level DEBUG
 The server will be available at:
 - Server: `http://127.0.0.1:8000/`
 - MCP endpoint: `http://127.0.0.1:8000/mcp`
+
+**Note:** The server runs in stateless mode, so no session IDs are required. Each request is handled independently, making it perfect for load balancing and scaling.
 
 ### Environment Variables
 

--- a/tim_mcp/server.py
+++ b/tim_mcp/server.py
@@ -604,12 +604,15 @@ def main(transport_config=None):
         # Explicit STDIO mode
         mcp.run()
     elif transport_config.mode == "http":
-        # HTTP mode with specified host and port
+        # HTTP mode with specified host and port (always stateless)
         logger.info(
-            f"Starting HTTP server on {transport_config.host}:{transport_config.port}"
+            f"Starting stateless HTTP server on {transport_config.host}:{transport_config.port}"
         )
         mcp.run(
-            transport="http", host=transport_config.host, port=transport_config.port
+            transport="http",
+            host=transport_config.host,
+            port=transport_config.port,
+            stateless_http=True,
         )
     else:
         raise ValueError(f"Unsupported transport mode: {transport_config.mode}")


### PR DESCRIPTION
### Description

FastMCP defaults to stateful http connection. This is not needed for our MCP and add unneeded complexity. 

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
