### PR TITLE
chore(ci): use dynamic versioning

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,14 +4,12 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/exec", {
-      "prepareCmd": "if [ -f pyproject.toml ]; then python3 -c \"import re; content = open('pyproject.toml').read(); content = re.sub(r'(version\\s*=\\s*)[\\\"\\'][^\\\"\\']+([\\\"\\'\\)])', r'\\\\1\\\"${nextRelease.version}\\\"\\\\2', content); open('pyproject.toml', 'w').write(content); print('Updated pyproject.toml version to ${nextRelease.version}')\"; else echo 'No pyproject.toml found, skipping Python version update'; fi",
-      "successCmd": "echo \"SEMVER_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
-    }],
+    "@semantic-release/github",
     ["@semantic-release/git", {
-      "assets": ["pyproject.toml"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      "assets": "false"
     }],
-    "@semantic-release/github"
+    ["@semantic-release/exec", {
+      "successCmd": "echo \"SEMVER_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
+    }]
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "tim-mcp"
-version = "1.2.0"
+# Version is managed dynamically via git tags using hatch-vcs
+# Do not add a static version field here as it will conflict with dynamic versioning
+dynamic = ["version"]
 description = "Terraform IBM Modules MCP"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -79,3 +81,9 @@ packages = ["tim_mcp"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "static" = "tim_mcp/static"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "tim_mcp/_version.py"


### PR DESCRIPTION
### Description

Because of our branch protection rules the `project.toml` cannot be updated on release. Instead remove the version from the `project.toml` and use dynamic versioning with `hatch-vcs` to automatically derive the version from git tags. This eliminates the need for semantic-release to commit version changes back to the repository, avoiding branch protection conflicts while maintaining proper versioning through git tags as the single source of truth.

patch release to catch the previous missing release

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
