### PR TITLE
feat: add source sanitization for Terraform examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![Experimental](https://img.shields.io/badge/status-experimental-orange.svg)](#)
 
-A Model Context Protocol (MCP) server that provides comprehensive Terraform module context for IBM Cloud architectures. This MCP server enhances the TIM Designer backend by bridging the gap between module discovery and implementation, enabling more accurate and context-aware Terraform code generation.
+A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/getting-started/intro) that provides structured access to the Terraform IBM Modules (TIM) ecosystem. TIM is a curated collection of IBM Cloud Terraform modules designed to follow best practices.
+
+This server acts as a bridge, enabling AI models and other tools to intelligently discover and utilize the extensive documentation, examples, and implementation patterns bundled with the [TIM modules](https://github.com/terraform-ibm-modules). It is designed to support AI-assisted coding workflows for creating IBM Cloud infrastructure.
+
+**About TIM:** [Terraform IBM Modules (TIM)](https://github.com/terraform-ibm-modules) is a collection of curated IBM Cloud Terraform modules available on the [Terraform Registry](https://registry.terraform.io/namespaces/terraform-ibm-modules). Full documentation is available at https://github.com/terraform-ibm-modules/documentation.
 
 ## Quick Start
 
@@ -54,25 +59,33 @@ Get started with TIM-MCP in Claude Desktop in under 2 minutes:
 
 ## Overview
 
-TIM-MCP combines data from the HashiCorp Terraform Registry with actual implementation details from GitHub repositories to provide rich context about IBM Cloud Terraform modules. While existing tools can search for modules and retrieve basic metadata, they lack access to real implementation code, working examples, and detailed integration patterns that are essential for generating production-ready Terraform configurations.
+This MCP server provides tools for AI models to navigate the [Terraform IBM Modules (TIM)](https://github.com/terraform-ibm-modules) ecosystem. TIM modules are bundled with extensive documentation, working examples, and architectural patterns, but these resources are distributed across many GitHub repositories.
 
-## Installation
+This server exposes a set of tools that allow an AI assistant to:
+- **Discover** relevant modules from the [Terraform Registry](https://registry.terraform.io/namespaces/terraform-ibm-modules).
+- **Inspect** module details, including inputs, outputs, and dependencies.
+- **Explore** the contents of a module's repository, such as examples and submodules.
+- **Retrieve** specific file contents, like example code or documentation.
 
-TIM-MCP requires Python 3.11 or higher and uses [uv](https://docs.astral.sh/uv/) for dependency management.
+The goal is to provide a structured and efficient way for an AI to gather the necessary context to generate accurate and high-quality Infrastructure as Code solutions for IBM Cloud.
 
-```bash
-# Install from PyPI (when published)
-uv tool install tim-mcp
+### Key Features
 
-# Install from source
-git clone https://github.com/terraform-ibm-modules/tim-mcp.git
-cd tim-mcp
-uv sync
-```
+- **Module Search**: Find modules in the Terraform Registry with quality-based ranking.
+- **Module Details**: Get structured information about a module's interface.
+- **Repository Exploration**: List the contents of a module's repository, including examples and submodules.
+- **Content Retrieval**: Fetch specific files from a module's repository.
+- **AI-Assisted Workflows**: The tools are designed to be used in sequence to support a typical AI-assisted coding workflow.
 
-## Development Setup
+### Important Notes
 
-To set up the development environment:
+⚠️ **Experimental Status**: This MCP server and the solutions it helps generate are experimental. Generated configurations should always be reviewed by skilled practitioners before use in any environment.
+
+⚠️ **Human Review Required**: Even when the tools and workflows mature, human expertise will remain essential for reviewing outputs, making final adjustments, and ensuring configurations meet specific requirements.
+
+## Development Installation
+
+For developers who want to contribute to TIM-MCP or run it locally for development purposes:
 
 ```bash
 # Clone the repository
@@ -88,6 +101,12 @@ uv run pytest
 # Run the server locally (STDIO mode - default)
 uv run tim-mcp
 ```
+
+**Requirements:**
+- Python 3.11 or higher
+- [uv](https://docs.astral.sh/uv/) package manager
+
+> **Note:** For most users, we recommend using the Quick Start guide above rather than installing locally. The Quick Start method automatically handles dependencies and is easier to maintain.
 
 ## Transport Modes
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Experimental](https://img.shields.io/badge/status-experimental-orange.svg)](#)
 
-A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/getting-started/intro) that provides structured access to the Terraform IBM Modules (TIM) ecosystem. TIM is a curated collection of IBM Cloud Terraform modules designed to follow best practices.
+A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/getting-started/intro) that provides structured access to the [Terraform IBM Modules (TIM)](https://github.com/terraform-ibm-modules) ecosystem. TIM is a curated collection of IBM Cloud Terraform modules designed to follow best practices. See the [Overview](#overview) for further details on rational.
 
 This server acts as a bridge, enabling AI models and other tools to intelligently discover and utilize the extensive documentation, examples, and implementation patterns bundled with the [TIM modules](https://github.com/terraform-ibm-modules). It is designed to support AI-assisted coding workflows for creating IBM Cloud infrastructure.
-
-**About TIM:** [Terraform IBM Modules (TIM)](https://github.com/terraform-ibm-modules) is a collection of curated IBM Cloud Terraform modules available on the [Terraform Registry](https://registry.terraform.io/namespaces/terraform-ibm-modules). Full documentation is available at https://github.com/terraform-ibm-modules/documentation.
 
 ## Quick Start
 
@@ -100,6 +98,9 @@ uv run pytest
 
 # Run the server locally (STDIO mode - default)
 uv run tim-mcp
+
+# Launch the MCP inspector
+npx @modelcontextprotocol/inspector uv run tim-mcp
 ```
 
 **Requirements:**
@@ -330,101 +331,6 @@ claude mcp remove tim-mcp
 After configuration, restart Claude Desktop completely. You should see a hammer icon (🔨) in the bottom left of the input box, indicating that MCP tools are available.
 
 Test the connection by asking Claude: "What IBM Cloud Terraform modules are available for VPC?"
-
-## Available MCP Tools
-
-Once configured, TIM-MCP provides these tools to Claude for comprehensive Terraform module discovery and implementation:
-
-### 1. `search_modules`
-**Search Terraform Registry for IBM Cloud modules with intelligent result optimization.**
-
-**Purpose:** Find relevant modules based on search terms, with results optimized by download count for better quality.
-
-**Inputs:**
-- `query` (string, required): Specific search term (e.g., "vpc", "kubernetes", "security")
-- `limit` (integer, optional): Maximum results to return (default: 10, range: 1-100)
-
-**Output:** JSON formatted search results including:
-- Module identifiers and basic metadata
-- Download counts and verification status
-- Descriptions and source repository URLs
-- Publication dates and version information
-
-**Usage Examples:**
-- Quick reference: `limit=3` for "I need a VPC module"
-- Exploring options: `limit=5-15` (default=5) for comparing alternatives
-- Comprehensive research: `limit=20+` for thorough analysis
-
-### 2. `get_module_details`
-**Retrieve structured module metadata from Terraform Registry - lightweight module interface overview.**
-
-**Purpose:** Get comprehensive module interface information including inputs, outputs, and dependencies without fetching source code.
-
-**Inputs:**
-- `module_id` (string, required): Full module identifier (e.g., "terraform-ibm-modules/vpc/ibm")
-- `version` (string, optional): Specific version or "latest" (default: "latest")
-
-**Output:** Markdown formatted module details including:
-- Module description and documentation
-- Required and optional input variables with types, descriptions, and defaults
-- Available outputs with types and descriptions
-- Provider requirements and version constraints
-- Module dependencies and available versions
-
-**When to Use:** First step after finding a module to understand its interface - often sufficient to answer user questions without fetching implementation files.
-
-### 3. `list_content`
-**Discover available paths in a module repository with README summaries.**
-
-**Purpose:** Explore repository structure to understand available examples, submodules, and solutions before fetching specific content.
-
-**Inputs:**
-- `module_id` (string, required): Full module identifier (e.g., "terraform-ibm-modules/vpc/ibm")
-- `version` (string, optional): Git tag/branch to scan (default: "latest")
-
-**Output:** Markdown formatted content listing organized by category:
-- **Root Module:** Main terraform files, inputs/outputs definitions
-- **Examples:** Deployable examples showing module usage (ideal starting point)
-- **Submodules:** Reusable components within the module
-- **Solutions:** Complete architecture patterns for complex scenarios
-
-**Usage Tips:** Use before `get_content` to select the most relevant path for your needs.
-
-### 4. `get_content`
-**Retrieve source code, examples, and documentation from GitHub repositories with targeted content filtering.**
-
-**Purpose:** Fetch actual implementation files, examples, and documentation with precise filtering to avoid large responses.
-
-**Inputs:**
-- `module_id` (string, required): Full module identifier (e.g., "terraform-ibm-modules/vpc/ibm")
-- `path` (string, optional): Specific path - "" (root), "examples/basic", "modules/vpc", etc.
-- `include_files` (list[string], optional): Glob patterns for files to include
-- `exclude_files` (list[string], optional): Glob patterns for files to exclude
-- `version` (string, optional): Git tag/branch to fetch from (default: "latest")
-
-**Output:** Markdown formatted content with file contents, organized by:
-- File paths and content with appropriate syntax highlighting
-- File sizes for reference
-- README files are included if they match the patterns (like any other file)
-
-**Common Glob Patterns:**
-- Input variables only: `include_files=["variables.tf"]`
-- Basic example: `path="examples/basic", include_files=["*.tf"]`
-- Complete module: `include_files=["*.tf"]`
-- Documentation: `include_files=["*.md"]`
-- README only: `include_files=["README.md"]`
-- Everything: `include_files=["*"]` (or omit entirely)
-
-## Tool Workflow
-
-The tools are designed to work together in an efficient workflow:
-
-1. **`search_modules`** → Find relevant modules
-2. **`get_module_details`** → Understand module interface (often sufficient)
-3. **`list_content`** → Explore repository structure if needed
-4. **`get_content`** → Fetch specific implementation details
-
-This progressive approach minimizes API calls and provides context-aware information at each step.
 
 ## Troubleshooting
 

--- a/tim_mcp/tools/get_content.py
+++ b/tim_mcp/tools/get_content.py
@@ -116,11 +116,23 @@ async def _get_content_with_client(
     for i, file_item in enumerate(filtered_files):
         result = results[i]
         if not isinstance(result, Exception):
+            file_content = result.get("decoded_content", "")
+            # If this is a Terraform file, replace source references
+            # NOTE: This sanitizes examples by replacing relative paths with absolute module references
+            if file_item["name"].endswith('.tf'):
+                # Strip 'v' prefix from version for Terraform compatibility (GitHub uses v1.2.3, Terraform uses 1.2.3)
+                terraform_version = resolved_version.lstrip('v')
+                # Replace source = "../.." or source = "../../" with source = "{base_module_id}" and add version
+                file_content = re.sub(
+                    r'source\s*=\s*"\.\.\/\.\.\/?"',
+                    f'source = "{base_module_id}"\n  version = "{terraform_version}"',
+                    file_content
+                )
             file_contents.append(
                 {
                     "name": file_item["name"],
                     "path": file_item["path"],
-                    "content": result.get("decoded_content", ""),
+                    "content": file_content,
                     "size": result.get("size", 0),
                 }
             )


### PR DESCRIPTION
### Description

When returning sanitized examples to an LLM, the Terraform code is immediately executable without requiring the LLM to understand relative path contexts or manually replace references. This enables the LLM to provide users with ready-to-deploy code snippets that work out-of-the-box.

This is restoring the original behaviour at https://github.com/terraform-ibm-modules/tim-mcp/blob/48a32e521b9625ff88380ca3a1bc81be4d3398e4/services/terraform_github.py#L74