### PR TITLE
feat: Add VS Code one-click install button for easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Visual Studio Code supports MCP servers through extension and configuration file
 
 4. Optionally add a `GITHUB_TOKEN` environment variable to avoid rate limits
 
+> **Note:** The VS Code button above configures MCP for VS Code's native MCP support. If you're using **Claude Code CLI** (the command-line tool), you need separate configuration. See the [Claude Code](#claude-code) section below for CLI setup.
+
 ### Claude Desktop
 
 Claude Desktop is a standalone application that supports MCP servers through a JSON configuration file.


### PR DESCRIPTION
### Description

- Add VS Code install button badge to README that uses the vscode:mcp/install URL scheme
- Enables users to install tim-mcp directly from README with a single click
- Works with VS Code 1.88.0+ with MCP extension installed
- Addresses issue #51 for streamlining MCP installation

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
