### PR TITLE
docs: replace duplicated TIM-MCP setup content with Cloud Docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/get
 
 ## Table of Contents
 - [Overview](#overview)
-- [Why TIM-MCP?](#why-tim-mcp)
 - [About TIM-MCP](#about-tim-mcp)
 - [Prerequisites](#prerequisites)
-- [Installation, Version Pinning, and Usage Workflows](#installation-version-pinning-and-usage-workflows)
+- [Install TIM-MCP](#install-tim-mcp)
 - [Troubleshooting](#troubleshooting)
 - [Configuration](#configuration)
 - [Additional Resources](#additional-resources)
@@ -38,28 +37,11 @@ The TIM-MCP server acts as a bridge between AI models and the Terraform IBM Modu
 
 ⚠️ **Human Review Required**: Even when the tools and workflows mature, human expertise will remain essential for reviewing outputs, making final adjustments, and ensuring configurations meet specific requirements.
 
-## Why TIM-MCP?
-
-TIM-MCP guides foundation models (FMs) to produce better IBM Cloud infrastructure solutions by:
-
-### Steering models toward best practices
-Without TIM-MCP, foundation models might generate generic or outdated Terraform code. TIM-MCP steers models toward IBM-validated patterns and current best practices by providing direct access to curated modules, preventing common anti-patterns and ensuring alignment with IBM Cloud architecture recommendations.
-
-### Providing contextual guardrails
-TIM-MCP acts as a guardrail system, helping models navigate the complex IBM Cloud ecosystem. It provides structured access to module interfaces, dependencies, and implementation patterns, reducing the likelihood of hallucinated parameters or incompatible resource combinations.
-
-### Enhancing precision with real-time module data
-Foundation models may have limited or outdated knowledge of IBM Cloud Terraform modules. TIM-MCP provides real-time access to module details, ensuring AI assistants generate code with accurate input variables, correct resource configurations, and proper module versioning.
-
-### Unlocking distributed knowledge
-By connecting models to documentation and examples spread across many repositories, TIM-MCP helps foundation models leverage the collective expertise embedded in the TIM ecosystem, resulting in more accurate and production-ready infrastructure code.
-
 ## About TIM-MCP
 
 TIM-MCP connects AI assistants to curated Terraform IBM Modules so generated infrastructure is more accurate, aligned to IBM Cloud best practices, and grounded in real module interfaces.
 
-To get started quickly:
-- Read [About TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim-mcp)
+To get started quickly, read [About TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim-mcp).
 
 
 ## Prerequisites
@@ -67,11 +49,9 @@ To get started quickly:
 Before setting up TIM-MCP, ensure your local environment and tooling are ready.
 Prerequisites: [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-prereqs)
 
-## Installation, Version Pinning, and Usage Workflows
+## Install TIM-MCP
 
-- **Installation:** Set up TIM-MCP with your preferred client by following the guided installation steps. [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp)
-- **Version Pinning:** Pinning versions helps keep behavior stable across teams and environments. [Using TIM-MCP - version pinning](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-version-pinning)
-- **Usage Workflows:** Use these examples to understand effective prompts and end-to-end TIM-MCP usage patterns. [Using TIM-MCP with AI assistants](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-using-tim-mcp-with-ai-assistants)
+For installation, version pinning, and usage workflows, see the [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp).
 
 ## Troubleshooting
 
@@ -79,11 +59,9 @@ If you face any issue, use the [troubleshooting guide](https://cloud.ibm.com/doc
 
 ## Configuration
 
-### Environment Variables
-
 #### Basic Configuration
 
-For most users running TIM-MCP locally, you only need:
+For most users running TIM-MCP locally, you only need these environment variables:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/get
 ## Table of Contents
 - [Overview](#overview)
 - [Why TIM-MCP?](#why-tim-mcp)
+- [About TIM-MCP](#about-tim-mcp)
 - [Prerequisites](#prerequisites)
-- [Installation Instructions](#installation-instructions)
-- [Version Pinning](#version-pinning)
-- [Using TIM-MCP](#using-tim-mcp)
+- [Installation, Version Pinning, and Usage Workflows](#installation-version-pinning-and-usage-workflows)
+- [Troubleshooting](#troubleshooting)
+- [Configuration](#configuration)
 - [Additional Resources](#additional-resources)
 - [For Developers](#for-developers)
 - [Contributing](#contributing)
@@ -53,13 +54,28 @@ Foundation models may have limited or outdated knowledge of IBM Cloud Terraform 
 ### Unlocking distributed knowledge
 By connecting models to documentation and examples spread across many repositories, TIM-MCP helps foundation models leverage the collective expertise embedded in the TIM ecosystem, resulting in more accurate and production-ready infrastructure code.
 
+## About TIM-MCP
+
+TIM-MCP connects AI assistants to curated Terraform IBM Modules so generated infrastructure is more accurate, aligned to IBM Cloud best practices, and grounded in real module interfaces.
+
+To get started quickly:
+- Read [About TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim-mcp)
+
+
 ## Prerequisites
 
-For prerequisites, follow the [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-prereqs).
+Before setting up TIM-MCP, ensure your local environment and tooling are ready.
+Prerequisites: [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-prereqs)
 
-## Installation Instructions
+## Installation, Version Pinning, and Usage Workflows
 
-For installation steps by client/tool, use the [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp).
+- **Installation:** Set up TIM-MCP with your preferred client by following the guided installation steps. [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp)
+- **Version Pinning:** Pinning versions helps keep behavior stable across teams and environments. [Using TIM-MCP - version pinning](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-version-pinning)
+- **Usage Workflows:** Use these examples to understand effective prompts and end-to-end TIM-MCP usage patterns. [Using TIM-MCP with AI assistants](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-using-tim-mcp-with-ai-assistants)
+
+## Troubleshooting
+
+If setup or runtime issues occur, use the troubleshooting guide to diagnose and resolve common errors. [Troubleshoot TIM-MCP errors](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error)
 
 ## Configuration
 
@@ -91,19 +107,6 @@ These settings are for advanced users deploying TIM-MCP in production or HTTP mo
 | `TIM_ALLOWED_NAMESPACES` | terraform-ibm-modules | Allowed module namespaces (comma-separated) |
 
 </details>
-
-<a id="version-pinning"></a><a id="verification"></a><a id="using-tim-mcp"></a>
-## Version Pinning
-
-For version pinning , see [IBM Cloud Docs - Using TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-version-pinning).
-
-## Using TIM-MCP
-
-Explore prompts and workflows in [IBM Cloud Docs - Using TIM-MCP with AI assistants](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-using-tim-mcp-with-ai-assistants).
-
-## Troubleshooting
-
-For troubleshooting, see [IBM Cloud Docs - Troubleshoot TIM-MCP errors](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error).
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once configured, your AI assistant can help you build IBM Cloud infrastructure f
 - "Design a Quick POC Setup: Rapidly deploy a minimal viable environment with compute instances, basic networking, and essential services for testing"
 - "Design a FS-Validated Architecture: Deploy compliant infrastructure meeting Financial Services requirements with HPCS encryption, audit logging, and regulatory controls"
 - "Design a Hub-Spoke Network: Create an enterprise network architecture with centralized connectivity, network segmentation, and secure VPC interconnection"
-  
+
 ## Troubleshooting
 
 If you face any issue, use the [troubleshooting guide](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error) to diagnose and resolve common errors.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/get
 ## Table of Contents
 - [Overview](#overview)
 - [About TIM-MCP](#about-tim-mcp)
-- [Prerequisites](#prerequisites)
 - [Install TIM-MCP](#install-tim-mcp)
 - [Troubleshooting](#troubleshooting)
 - [Configuration](#configuration)
 - [Additional Resources](#additional-resources)
-- [For Developers](#for-developers)
 - [Contributing](#contributing)
 
 ## Overview
@@ -41,17 +39,11 @@ The TIM-MCP server acts as a bridge between AI models and the Terraform IBM Modu
 
 TIM-MCP connects AI assistants to curated Terraform IBM Modules so generated infrastructure is more accurate, aligned to IBM Cloud best practices, and grounded in real module interfaces.
 
-To get started quickly, read [About TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim-mcp).
-
-
-## Prerequisites
-
-Before setting up TIM-MCP, ensure your local environment and tooling are ready.
-Prerequisites: [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-prereqs)
+To get started quickly, read [about TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim-mcp).
 
 ## Install TIM-MCP
 
-For installation, version pinning, and usage workflows, see the [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp).
+For installation, version pinning, and usage workflows, follow the instructions provided in [TIM-MCP tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp).
 
 ## Troubleshooting
 
@@ -68,8 +60,7 @@ For most users running TIM-MCP locally, you only need these environment variable
 | `GITHUB_TOKEN` | Recommended | None | GitHub PAT for API rate limits (5000 req/hr vs 60 req/hr) |
 | `TIM_LOG_LEVEL` | No | INFO | Logging level (DEBUG, INFO, WARNING, ERROR) |
 
-<details>
-<summary><strong>Advanced Configuration (Production/Hosting)</strong></summary>
+#### Advanced Configuration (Production/Hosting)
 
 These settings are for advanced users deploying TIM-MCP in production or HTTP mode:
 
@@ -84,8 +75,6 @@ These settings are for advanced users deploying TIM-MCP in production or HTTP mo
 | `TIM_REQUEST_TIMEOUT` | 30 | External API timeout in seconds |
 | `TIM_ALLOWED_NAMESPACES` | terraform-ibm-modules | Allowed module namespaces (comma-separated) |
 
-</details>
-
 ## Additional Resources
 
 - **TIM-MCP Repository:** https://github.com/terraform-ibm-modules/tim-mcp
@@ -93,10 +82,8 @@ These settings are for advanced users deploying TIM-MCP in production or HTTP mo
 - **GitHub API Rate Limit Docs:** https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 - **Terraform Registry (IBM Modules):** https://registry.terraform.io/namespaces/terraform-ibm-modules
 
-## For Developers
+## Contributing
 
 If you're interested in contributing to TIM-MCP or modifying the server itself, please see the [Development Guide](DEVELOPMENT.md) for detailed instructions on development setup, transport modes, and advanced configuration options.
-
-## Contributing
 
 You can report issues and request features for this module in GitHub issues in the module repo. See [Report an issue or request a feature](https://github.com/terraform-ibm-modules/.github/blob/main/.github/SUPPORT.md).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/get
 - [Overview](#overview)
 - [About TIM-MCP](#about-tim-mcp)
 - [Install TIM-MCP](#install-tim-mcp)
+- [Using TIM-MCP](#using-tim-mcp)
 - [Troubleshooting](#troubleshooting)
 - [Configuration](#configuration)
 - [Additional Resources](#additional-resources)
@@ -45,6 +46,24 @@ To get started quickly, read [about TIM-MCP](https://cloud.ibm.com/docs/ibm-clou
 
 For installation, version pinning, and usage workflows, follow the instructions provided in [TIM-MCP tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp).
 
+## Using TIM-MCP
+
+Once configured, your AI assistant can help you build IBM Cloud infrastructure from simple to complex deployments. Ask for help with scenarios like:
+
+### Getting Started with IBM Cloud
+- "I am new to IBM Cloud. Help me create a simple and cheap OpenShift cluster and access the console"
+- "I want to create a simple basic virtual server on IBM Cloud and SSH to it"
+
+### Building Enterprise Infrastructure
+- "Design a VPC + OpenShift: Create a complete container platform with networking, including multi-zone VPC, subnets, OpenShift/ROKS cluster, and load balancers"
+- "Design a Secure Landing Zone: Implement enterprise-grade security with network isolation, encryption key management, private endpoints, and security groups"
+- "Design a Multi-Zone HA Database: Design resilient database infrastructure across 3+ availability zones with automated failover, backup strategies, and disaster recovery"
+
+### Quick Solutions
+- "Design a Quick POC Setup: Rapidly deploy a minimal viable environment with compute instances, basic networking, and essential services for testing"
+- "Design a FS-Validated Architecture: Deploy compliant infrastructure meeting Financial Services requirements with HPCS encryption, audit logging, and regulatory controls"
+- "Design a Hub-Spoke Network: Create an enterprise network architecture with centralized connectivity, network segmentation, and secure VPC interconnection"
+  
 ## Troubleshooting
 
 If you face any issue, use the [troubleshooting guide](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error) to diagnose and resolve common errors.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,7 @@ A [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/docs/get
 - [Why TIM-MCP?](#why-tim-mcp)
 - [Prerequisites](#prerequisites)
 - [Installation Instructions](#installation-instructions)
-  - [Claude Desktop](#claude-desktop)
-  - [VS Code](#vs-code)
-  - [Cursor](#cursor)
-  - [IBM Bob](#ibm-bob)
-  - [Claude Code](#claude-code)
 - [Version Pinning](#version-pinning)
-- [Verification](#verification)
-- [Troubleshooting](#troubleshooting)
 - [Using TIM-MCP](#using-tim-mcp)
 - [Additional Resources](#additional-resources)
 - [For Developers](#for-developers)
@@ -62,21 +55,13 @@ By connecting models to documentation and examples spread across many repositori
 
 ## Prerequisites
 
-Review required tools and preparation steps in [IBM Cloud Docs - Before you begin](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-before-you-begin).
+For prerequisites, follow the [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-prereqs).
 
 ## Installation Instructions
 
-For installation steps by client/tool, see IBM Cloud Docs:
-
-- <a id="claude-desktop"></a>**Claude Desktop:** [IBM Cloud Docs - Claude Desktop setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-claude-desktop)
-- <a id="vs-code"></a>**VS Code:** [IBM Cloud Docs - VS Code setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-vscode)
-- <a id="cursor"></a>**Cursor:** [IBM Cloud Docs - Cursor setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-cursor)
-- <a id="ibm-bob"></a>**IBM Bob:** [IBM Cloud Docs - IBM Project Bob setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-ibm-bob)
-- <a id="claude-code"></a>**Claude Code:** [IBM Cloud Docs - Claude Code setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-claude-code)
+For installation steps by client/tool, use the [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp).
 
 ## Configuration
-
-See environment and config details in [IBM Cloud Docs - Configuration guidance](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-project-bob).
 
 ### Environment Variables
 
@@ -107,13 +92,10 @@ These settings are for advanced users deploying TIM-MCP in production or HTTP mo
 
 </details>
 
+<a id="version-pinning"></a><a id="verification"></a><a id="using-tim-mcp"></a>
 ## Version Pinning
 
-Use [IBM Cloud Docs - Version pinning for production](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-version-pinning) for stable production deployments.
-
-## Verification
-
-Validate the setup with [IBM Cloud Docs - Verification steps](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-claude-desktop).
+For version pinning , see [IBM Cloud Docs - Using TIM-MCP](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-version-pinning).
 
 ## Using TIM-MCP
 
@@ -121,7 +103,7 @@ Explore prompts and workflows in [IBM Cloud Docs - Using TIM-MCP with AI assista
 
 ## Troubleshooting
 
-Resolve common issues using [IBM Cloud Docs - Troubleshoot TIM-MCP errors](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error).
+For troubleshooting, see [IBM Cloud Docs - Troubleshoot TIM-MCP errors](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error).
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -62,150 +62,21 @@ By connecting models to documentation and examples spread across many repositori
 
 ## Prerequisites
 
-Before configuring TIM-MCP, ensure you have the following installed:
-
-1. **uv Package Manager** (required for running the MCP server)
-
-   **macOS/Linux:**
-   ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh
-   ```
-
-   **Windows:**
-   ```powershell
-   winget install --id=astral-sh.uv -e
-   ```
-
-   Verify installation:
-   ```bash
-   uv --version
-   ```
-
-2. **GitHub Personal Access Token** (optional but recommended)
-
-   A GitHub token helps avoid API rate limits when accessing TIM repositories:
-   - Without token: 60 requests/hour
-   - With token: 5,000 requests/hour
-
-   To create a token:
-   - Go to: **GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens**
-   - Create a token with:
-     - **Repository access:** "Public repositories only"
-     - **Permissions:** No private access scopes needed
-     - **Expiration:** Set to 90 days or longer
+Review required tools and preparation steps in [IBM Cloud Docs - Before you begin](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-before-you-begin).
 
 ## Installation Instructions
 
-### Claude Desktop
+For installation steps by client/tool, see IBM Cloud Docs:
 
-Claude Desktop is a standalone application that supports MCP servers through a JSON configuration file.
-
-1. **Install uv** (if not already installed) - see Prerequisites section
-
-2. **Add TIM-MCP Configuration**:
-   - **macOS:** Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - **Windows:** Edit `%APPDATA%\Claude\claude_desktop_config.json`
-
-   **Basic Configuration:**
-   ```json
-   {
-     "mcpServers": {
-       "tim-mcp": {
-         "command": "uvx",
-         "args": [
-           "--from",
-           "git+https://github.com/terraform-ibm-modules/tim-mcp.git",
-           "tim-mcp"
-         ]
-       }
-     }
-   }
-   ```
-
-   **With GitHub Token** (recommended to avoid rate limits):
-   ```json
-   {
-     "mcpServers": {
-       "tim-mcp": {
-         "command": "uvx",
-         "args": [
-           "--from",
-           "git+https://github.com/terraform-ibm-modules/tim-mcp.git",
-           "tim-mcp"
-         ],
-         "env": { "GITHUB_TOKEN": "your_github_token_here" }
-       }
-     }
-   }
-   ```
-
-3. **Restart Claude Desktop** and look for the 🔨 icon to confirm MCP tools are loaded
-
-4. **Test it**: Ask Claude "What IBM Cloud VPC modules are available?"
-
-### VS Code
-
-Visual Studio Code supports MCP servers through extension and configuration files.
-
-1. **Install the MCP extension** for VS Code if not already installed
-
-2. **Configure TIM-MCP** using one of these methods:
-   - Create/edit `.vscode/mcp.json` in your project directory
-   - Use the Command Palette (Ctrl+Shift+P or Cmd+Shift+P) and select "MCP: Add Server"
-
-3. **Add the configuration** using the same JSON format as shown in the [Claude Desktop](#claude-desktop) section
-
-### Cursor
-
-Cursor IDE supports MCP servers through configuration files.
-
-1. **Create/edit** one of these files:
-   - `.cursor/mcp.json` in your project directory
-   - `~/.cursor/mcp.json` for global configuration
-
-2. **Add the configuration** using the same JSON format as shown in the [Claude Desktop](#claude-desktop) section
-
-### IBM Bob
-
-[IBM Bob](https://www.ibm.com/products/bob) supports MCP servers through configuration files.
-
-#### Configuring MCP Servers in Bob
-
-MCP server configurations can be managed at two levels:
-
-- **Project-level Configuration**: Create the file `.bob/mcp.json` within your project directory, and then **add the configuration** using the JSON format shown in the [Claude Desktop](#claude-desktop) section
-- **Global Configuration**: Stored in the `mcp_settings.json` file, accessible via VS Code settings. These settings apply across all your workspaces unless overridden by a project-level configuration.
-  1. Click the icon in the top navigation of the Bob pane.
-  2. Scroll to the bottom of the MCP settings view.
-  3. Click **Edit Global MCP**: Opens the global `mcp_settings.json` file.
-  4. Add the configuration using the same JSON format as shown in the [Claude Desktop](#claude-desktop) section
-
-
-### Claude Code
-
-Claude Code supports configuration via CLI or config file. The configuration format is similar to the [Claude Desktop](#claude-desktop) section.
-
-**CLI Method:**
-```bash
-# Navigate to your project directory first
-cd /path/to/your/project
-
-# Add the MCP server with GitHub token
-claude mcp add tim-mcp --env GITHUB_TOKEN=your_github_token_here \
-  -- uvx --from git+https://github.com/terraform-ibm-modules/tim-mcp.git tim-mcp
-
-# Or without GitHub token (may hit rate limits)
-claude mcp add tim-mcp -- uvx --from git+https://github.com/terraform-ibm-modules/tim-mcp.git tim-mcp
-
-# List configured MCP servers
-claude mcp list
-
-# Remove if needed
-claude mcp remove tim-mcp
-```
-
+- <a id="claude-desktop"></a>**Claude Desktop:** [IBM Cloud Docs - Claude Desktop setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-claude-desktop)
+- <a id="vs-code"></a>**VS Code:** [IBM Cloud Docs - VS Code setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-vscode)
+- <a id="cursor"></a>**Cursor:** [IBM Cloud Docs - Cursor setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-cursor)
+- <a id="ibm-bob"></a>**IBM Bob:** [IBM Cloud Docs - IBM Project Bob setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-ibm-bob)
+- <a id="claude-code"></a>**Claude Code:** [IBM Cloud Docs - Claude Code setup](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-claude-code)
 
 ## Configuration
+
+See environment and config details in [IBM Cloud Docs - Configuration guidance](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-project-bob).
 
 ### Environment Variables
 
@@ -238,76 +109,19 @@ These settings are for advanced users deploying TIM-MCP in production or HTTP mo
 
 ## Version Pinning
 
-For production use, pin to a specific version to ensure consistent behavior (using the same format as in the [Claude Desktop](#claude-desktop) section):
-
-```json
-{
-  "mcpServers": {
-    "tim-mcp": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/terraform-ibm-modules/tim-mcp.git@vX.X.X",
-        "tim-mcp"
-      ],
-      "env": { "GITHUB_TOKEN": "your_github_token_here" }
-    }
-  }
-}
-```
-
-> **Note:** Check the [releases page](https://github.com/terraform-ibm-modules/tim-mcp/releases) for the latest version tag.
+Use [IBM Cloud Docs - Version pinning for production](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-version-pinning) for stable production deployments.
 
 ## Verification
 
-After configuration:
-
-1. **Restart** your IDE or Claude Desktop completely
-2. **Check** for the hammer icon (🔨) in the input box, indicating MCP tools are available
-3. **Test** by asking: "What IBM Cloud Terraform modules are available for VPC?"
-
-## Troubleshooting
-
-### Common Issues and Solutions
-
-**Server not starting:**
-- Ensure `uv` is installed and available in your PATH
-- Verify your MCP configuration JSON syntax is valid
-
-**No tools appearing:**
-- Restart your IDE or Claude Desktop completely
-- Check logs for error messages
-
-**Rate limiting errors:**
-- Add a `GITHUB_TOKEN` environment variable with a valid GitHub personal access token
-- The token needs only public repository access permissions
-
-**Token Authentication Fails:**
-1. Verify token is valid and not expired
-2. Check token has public repository access
-3. Ensure token is in quotes in JSON
-4. Test token manually:
-```bash
-curl -H "Authorization: token YOUR_TOKEN" https://api.github.com/user
-```
+Validate the setup with [IBM Cloud Docs - Verification steps](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-claude-desktop).
 
 ## Using TIM-MCP
 
-Once configured, your AI assistant can help you build IBM Cloud infrastructure from simple to complex deployments. Ask for help with scenarios like:
+Explore prompts and workflows in [IBM Cloud Docs - Using TIM-MCP with AI assistants](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-using-tim-mcp#tim-mcp-using-tim-mcp-with-ai-assistants).
 
-### Getting Started with IBM Cloud
-- "I am new to IBM Cloud. Help me create a simple and cheap OpenShift cluster and access the console"
-- "I want to create a simple basic virtual server on IBM Cloud and SSH to it"
+## Troubleshooting
 
-### Building Enterprise Infrastructure
-- "Design a VPC + OpenShift: Create a complete container platform with networking, including multi-zone VPC, subnets, OpenShift/ROKS cluster, and load balancers"
-- "Design a Secure Landing Zone: Implement enterprise-grade security with network isolation, encryption key management, private endpoints, and security groups"
-- "Design a Multi-Zone HA Database: Design resilient database infrastructure across 3+ availability zones with automated failover, backup strategies, and disaster recovery"
-
-### Quick Solutions
-- "Design a Quick POC Setup: Rapidly deploy a minimal viable environment with compute instances, basic networking, and essential services for testing"
-- "Design a FS-Validated Architecture: Deploy compliant infrastructure meeting Financial Services requirements with HPCS encryption, audit logging, and regulatory controls"
-- "Design a Hub-Spoke Network: Create an enterprise network architecture with centralized connectivity, network segmentation, and secure VPC interconnection"
+Resolve common issues using [IBM Cloud Docs - Troubleshoot TIM-MCP errors](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error).
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Prerequisites: [TIM-MCP Tutorial](https://cloud.ibm.com/docs/ibm-cloud-provider-
 
 ## Troubleshooting
 
-If setup or runtime issues occur, use the troubleshooting guide to diagnose and resolve common errors. [Troubleshoot TIM-MCP errors](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error)
+If you face any issue, use the [troubleshooting guide](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-troubleshoot-tim-mcp-error) to diagnose and resolve common errors.
 
 ## Configuration
 


### PR DESCRIPTION
### Description

This PR updates the README.md to reduce duplicate documentation and direct users to IBM Cloud Docs.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
